### PR TITLE
BPL Customization and Version Bump

### DIFF
--- a/client/app/src/network/NetworkService.js
+++ b/client/app/src/network/NetworkService.js
@@ -308,7 +308,7 @@
 
     function getLatestClientVersion() {
         var deferred = $q.defer();
-        var url = 'https://api.github.com/repos/ArkEcosystem/ark-desktop/releases/latest';
+        var url = 'https://api.github.com/repos/blockpool-io/BPL-desktop/releases/latest';
         $http.get(url, {timeout: 5000})
             .then(function(res) {
                 deferred.resolve(res.data.tag_name);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bplclient",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "productName": "Blockpool Desktop",
   "description": "Blockpool Desktop",
   "main": "main.js",


### PR DESCRIPTION
Part of the problem with the new release bug is there is no latest release on the github. A release needs to be made with the 1.2.3 tag and listed as latest to give a return like this

https://api.github.com/repos/billotronic/bpl-desktop/releases/latest

Also, I cooked new windows bins here:

https://github.com/billotronic/BPL-desktop/releases

